### PR TITLE
Accept IP address in FQDN parameter

### DIFF
--- a/Template APP Blacklist/check_dnsbl.sh
+++ b/Template APP Blacklist/check_dnsbl.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 blstatus=0
-IP=$(host -t a $1 | grep addre | awk '{print $4}')
+if [[ $1 =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+    IP=$1
+else
+    IP=$(host -t a $1 | grep addre | awk '{print $4}')
+fi
 r_ip=$(echo $IP|awk -F"." '{for(i=NF;i>0;i--) printf i!=1?$i".":"%s",$i}')
 result=$(dig +short $r_ip.$2)
 


### PR DESCRIPTION
Modify verify script to accept IP address in FQDN parameter.
This is usefull when FQDN point to internal IP of server.